### PR TITLE
[fix] 홈 진입 시 사용자 정보 조회로 로딩 버그 수정(#68)

### DIFF
--- a/app/routes/home/index.tsx
+++ b/app/routes/home/index.tsx
@@ -13,20 +13,17 @@ export default function Home() {
   const [hasMatch, setHasMatch] = useState<boolean | null>(null);
   const me = useAuthStore((s) => s.me);
   const setMe = useAuthStore((s) => s.setMe);
-  const [resolvedHasMatchingTest, setResolvedHasMatchingTest] = useState<
-    boolean | null
-  >(null);
+  const hasTokens = tokenStorage.hasTokens();
+  const resolvedHasMatchingTest =
+    me?.matchingTestDone !== undefined
+      ? Boolean(me.matchingTestDone)
+      : hasTokens
+        ? null
+        : false;
 
   useEffect(() => {
-    if (me?.matchingTestDone !== undefined) {
-      setResolvedHasMatchingTest(Boolean(me.matchingTestDone));
-      return;
-    }
-
-    if (!tokenStorage.hasTokens()) {
-      setResolvedHasMatchingTest(false);
-      return;
-    }
+    if (me?.matchingTestDone !== undefined) return;
+    if (!hasTokens) return;
 
     let isMounted = true;
 
@@ -45,10 +42,11 @@ export default function Home() {
           avatarUrl: result.profileImageUrl ?? undefined,
           matchingTestDone: Boolean(result.hasMatchingTest),
         });
-        setResolvedHasMatchingTest(Boolean(result.hasMatchingTest));
       } catch (error) {
         console.error("Failed to load my page info:", error);
-        if (isMounted) setResolvedHasMatchingTest(false);
+        if (isMounted) {
+          setMe({ matchingTestDone: false });
+        }
       }
     };
 
@@ -57,7 +55,7 @@ export default function Home() {
     return () => {
       isMounted = false;
     };
-  }, [me?.matchingTestDone, setMe]);
+  }, [hasTokens, me?.matchingTestDone, setMe]);
 
   useEffect(() => {
     if (resolvedHasMatchingTest !== true) return;

--- a/app/routes/mypage/likes/likes-content.tsx
+++ b/app/routes/mypage/likes/likes-content.tsx
@@ -63,6 +63,15 @@ type CampaignLike = {
   logoUrl?: string | null;
 };
 
+const SORT_PARAM_MAP: Record<string, string> = {
+  "정렬 필터": "matchingRate",
+  "매칭률 순": "matchingRate",
+  "인기 순": "popularity",
+  "신규 순": "latest",
+  "금액 순": "reward",
+  "마감 순": "dDay",
+};
+
 export default function MyPageLikes() {
   useHideHeader(true);
   const navigate = useNavigate();
@@ -108,15 +117,6 @@ export default function MyPageLikes() {
     return list;
   }, [sortOption, campaignLikesApi]);
 
-  const sortParamMap: Record<string, string> = {
-    "정렬 필터": "matchingRate",
-    "매칭률 순": "matchingRate",
-    "인기 순": "popularity",
-    "신규 순": "latest",
-    "금액 순": "reward",
-    "마감 순": "dDay",
-  };
-
   useEffect(() => {
     let isMounted = true;
     const fetchScrap = async () => {
@@ -127,7 +127,7 @@ export default function MyPageLikes() {
           {
             params: {
               type: activeTab === "brand" ? "brand" : "campaign",
-              sort: sortParamMap[sortOption] ?? "matchingRate",
+              sort: SORT_PARAM_MAP[sortOption] ?? "matchingRate",
             },
           },
         );


### PR DESCRIPTION
## 작업 내용
홈 최초 진입 시 토큰이 존재하는 경우 사용자 정보를 조회해 `matchingTestDone` 값을 보완하고, 로딩 상태가 해제되도록 처리했습니다.

## 변경 사항
- 홈 진입 시 토큰 여부 확인 후 `/api/v1/users/me` 호출
- 조회 결과를 store에 반영하여 매칭 테스트 여부 상태를 확정
- 토큰 미존재 시 바로 PreHome로 분기

## 스크린샷 (선택사항)
